### PR TITLE
build: move dependencies into peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "url": "https://github.com/VadimDez/ng2-pdf-viewer/issues"
   },
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
-  "dependencies": {
-    "@types/pdfjs-dist": "^2.1.7",
-    "pdfjs-dist": "^2.5.207",
+  "peerDependencies": {
+    "@types/pdfjs-dist": "2.1.7",
+    "pdfjs-dist": "2.5.207",
     "tslib": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
prevent project conflicts